### PR TITLE
Reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Output option "append_environment". Appends environment settings to output.
 - Filebench workload type added.
 - Validation argument (i.e. `iobs validation`) to validate files without execution.
+- `-d` `--reset-device` argument added. Resets device to prior execution state
+after execution.
 
 ### Fixed
 - Template settings should appear in output if specified in format.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Executes one or more `iobs` configuration files.
 ```bash
 $ iobs execute -h
 usage: iobs execute [-h] [-o OUTPUT_DIRECTORY] [-l LOG_FILE]
-                    [--log-level {1,2,3}] [-s] [-r RETRY_COUNT] [-c]
+                    [--log-level {1,2,3}] [-s] [-r RETRY_COUNT] [-c] [-d]
                     input [input ...]
 
 positional arguments:
@@ -69,6 +69,8 @@ optional arguments:
   -c, --continue-on-failure
                         If a input fails, continues executing other inputs;
                         otherwise exits the program.
+  -d, --reset-device    Resets the device to original settings after
+                        execution of each input.
 ```
 
 ### `iobs validate`

--- a/iobs/commands/execute.py
+++ b/iobs/commands/execute.py
@@ -133,7 +133,7 @@ def execute(args):
                    print_type=PrintType.ERROR | PrintType.ERROR_LOG)
         finally:
             if args.reset_device:
-                configuration.reset_device_environments()
+                configuration.restore_device_environments()
 
     printf('Finishing program execution...',
            print_type=PrintType.NORMAL | PrintType.INFO_LOG)

--- a/iobs/commands/execute.py
+++ b/iobs/commands/execute.py
@@ -48,9 +48,10 @@ def check_args(args):
     else:
         SettingsManager.set('log_enabled', False)
 
-    SettingsManager.set('silent', args.silent)
-    SettingsManager.set('retry_count', args.retry_count)
     SettingsManager.set('continue_on_failure', args.continue_on_failure)
+    SettingsManager.set('reset_device', args.reset_device)
+    SettingsManager.set('retry_count', args.retry_count)
+    SettingsManager.set('silent', args.silent)
 
 
 def get_log_level(log_level):
@@ -118,6 +119,10 @@ def execute(args):
 
             configuration = parse_config_file(input_file)
             configuration.validate()
+
+            if args.reset_device:
+                configuration.save_device_environments()
+
             configuration.process()
         except IOBSBaseException as err:
             if not SettingsManager.get('continue_on_failure'):
@@ -126,6 +131,9 @@ def execute(args):
             printf('input file {} failed all retries. Continuing execution '
                    'of remaining files...\n{}'.format(input_file, err),
                    print_type=PrintType.ERROR | PrintType.ERROR_LOG)
+        finally:
+            if args.reset_device:
+                configuration.reset_device_environments()
 
     printf('Finishing program execution...',
            print_type=PrintType.NORMAL | PrintType.INFO_LOG)
@@ -182,6 +190,14 @@ def main(args):
         action='store_true',
         help='If a input fails, continues executing other inputs; otherwise '
              'exits the program.'
+    )
+    parser.add_argument(
+        '-d', '--reset-device',
+        dest='reset_device',
+        default=False,
+        action='store_true',
+        help='Resets the device to original settings after execution of each '
+             'input.'
     )
 
     args = parser.parse_args(args)

--- a/iobs/config/base.py
+++ b/iobs/config/base.py
@@ -199,8 +199,8 @@ class Configuration:
                 continue
 
             de = self._device_environments[device]
-            change_nomerges(device, de.nomerges)
-            change_scheduler(device, de.scheduler)
+            change_nomerges(device, de['nomerges'])
+            change_scheduler(device, de['scheduler'])
 
     def save_device_environments(self):
         """Saves device environment information so it can be restored.

--- a/iobs/config/base.py
+++ b/iobs/config/base.py
@@ -194,11 +194,18 @@ class Configuration:
         NOTE: This should be called after `save_device_environments` has been
         called.
         """
+        printf('Restoring device information...',
+               print_type=PrintType.DEBUG_LOG)
+
         for device in self._global_configuration.devices:
             if device not in self._device_environments:
                 continue
 
             de = self._device_environments[device]
+
+            printf('Restoring device {} environment: {}'.format(device, de),
+                   print_type=PrintType.DEBUG_LOG)
+
             change_nomerges(device, de['nomerges'])
             change_scheduler(device, de['scheduler'])
 
@@ -207,11 +214,19 @@ class Configuration:
 
         NOTE: This should be called after `validate` has bee called.
         """
+        printf('Saving device information...',
+               print_type=PrintType.DEBUG_LOG)
+
         for device in self._global_configuration.devices:
             self._device_environments[device] = {
                 'nomerges': get_device_nomerges(device),
                 'scheduler': get_device_scheduler(device)
             }
+
+            de = self._device_environments[device]
+
+            printf('Saving device {} environment: {}'.format(device, de),
+                   print_type=PrintType.DEBUG_LOG)
 
     def validate(self):
         """Validates the configuration."""

--- a/iobs/config/base.py
+++ b/iobs/config/base.py
@@ -195,7 +195,7 @@ class Configuration:
         called.
         """
         for device in self._global_configuration.devices:
-            if device not in de:
+            if device not in self._device_environments:
                 continue
 
             de = self._device_environments[device]

--- a/iobs/config/base.py
+++ b/iobs/config/base.py
@@ -19,6 +19,12 @@ from abc import ABC, abstractmethod
 
 from iobs.errors import InvalidSettingError
 from iobs.output import printf, PrintType
+from iobs.process import (
+    change_nomerges,
+    change_scheduler,
+    get_device_nomerges,
+    get_device_scheduler
+)
 
 
 class ConfigAttribute:
@@ -158,6 +164,7 @@ class Configuration:
         self._template_configuration = template_configuration
         self._environment_configuration = environment_configuration
         self._workload_configurations = []
+        self._device_environments = {}
 
     def add_workload_configuration(self, workload_configuration):
         """Adds a WorkloadConfiguration to process.
@@ -180,6 +187,31 @@ class Configuration:
                 self._template_configuration,
                 self._environment_configuration
             )
+
+    def restore_device_environments(self):
+        """Restores device environments.
+
+        NOTE: This should be called after `save_device_environments` has been
+        called.
+        """
+        for device in self._global_configuration.devices:
+            if device not in de:
+                continue
+
+            de = self._device_environments[device]
+            change_nomerges(device, de.nomerges)
+            change_scheduler(device, de.scheduler)
+
+    def save_device_environments(self):
+        """Saves device environment information so it can be restored.
+
+        NOTE: This should be called after `validate` has bee called.
+        """
+        for device in self._global_configuration.devices:
+            self._device_environments[device] = {
+                'nomerges': get_device_nomerges(device),
+                'scheduler': get_device_scheduler(device)
+            }
 
     def validate(self):
         """Validates the configuration."""

--- a/iobs/process.py
+++ b/iobs/process.py
@@ -279,6 +279,60 @@ def get_device_major_minor(device):
 
     return out
 
+def get_device_nomerges(device):
+    """Returns the current nomerges for the device.
+
+    Args:
+        device: The device.
+
+    Returns:
+        The current nomerges setting.
+    """
+    printf('Retrieving nomerges for device {}'.format(device),
+           print_type=PrintType.DEBUG_LOG)
+
+    device_name = match_regex(device, 'device_name')
+
+    out, rc = run_command('cat /sys/block/{}/queue/nomerges'.format(device_name))
+
+    if rc != 0:
+        printf('Unable to find nomerges for device',
+               print_type=PrintType.ERROR_LOG)
+        return []
+
+    return int(out)
+
+
+def get_device_scheduler(device):
+    """Returns the current scheduler for the device.
+
+    Args:
+        device: The device.
+
+    Returns:
+        The current scheduler.
+    """
+    printf('Retrieving schedulers for device {}'.format(device),
+           print_type=PrintType.DEBUG_LOG)
+
+    device_name = match_regex(device, 'device_name')
+
+    out, rc = run_command('cat /sys/block/{}/queue/scheduler'.format(device_name))
+
+    if rc != 0:
+        printf('Unable to find schedulers for device',
+               print_type=PrintType.ERROR_LOG)
+        return []
+
+    l, r = out.index('['), out.index(']')
+    ret = out[l+1:r]
+
+    printf('Found the current scheduler for device {}: '
+           '{}'.format(device, ret),
+           print_type=PrintType.DEBUG_LOG)
+
+    return ret
+
 
 def get_schedulers_for_device(device):
     """Returns a list of available schedulers for a given device.

--- a/iobs/settings.py
+++ b/iobs/settings.py
@@ -49,6 +49,7 @@ class SettingsManager:
     continue_on_failure = False
     log_enabled = False
     output_directory = os.getcwd()
+    reset_device = False
     retry_count = 1
     silent = False
 


### PR DESCRIPTION
Adding `-d` `--reset-device` flag to resets device to configuration prior to execution for each input file.

Currently resets `nomerges` and `scheduler` back to prior state.