### PR TITLE
fix-blktrace

### DIFF
--- a/iobs/config/jobs.py
+++ b/iobs/config/jobs.py
@@ -159,10 +159,10 @@ class Job(ABC):
                 if line[:3] in ('D2C', 'Q2C'):
                     t = line[:3].lower()
                     ls = line.split()
-                    ret['{}_min'.format(t)] = ls[1]
-                    ret['{}_avg'.format(t)] = ls[2]
-                    ret['{}_max'.format(t)] = ls[3]
-                    ret['{}_n'.format(t)] = ls[4]
+                    ret['{}-min'.format(t)] = ls[1]
+                    ret['{}-avg'.format(t)] = ls[2]
+                    ret['{}-max'.format(t)] = ls[3]
+                    ret['{}-n'.format(t)] = ls[4]
 
             return ret
         except (KeyError, IndexError) as err:

--- a/iobs/config/outputs.py
+++ b/iobs/config/outputs.py
@@ -234,14 +234,14 @@ class OutputConfiguration(ConfigSectionBase):
 
     def _get_blktrace_order(self):
         return [
-            'd2c_avg',
-            'd2c_max',
-            'd2c_min',
-            'd2c_n',
-            'q2c_avg',
-            'q2c_max',
-            'q2c_min',
-            'q2c_n'
+            'd2c-avg',
+            'd2c-max',
+            'd2c-min',
+            'd2c-n',
+            'q2c-avg',
+            'q2c-max',
+            'q2c-min',
+            'q2c-n'
         ]
 
 


### PR DESCRIPTION
Blktrace output now properly uses `-` instead of `_` for separators.