### PR TITLE
Fix address randomization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed output parsing exception being handled properly.
+- Fixed filebench stalling. Set /sys/proc/kernel/randomize_va_space to 0.
 
 ## [1.1.0] - 2019-03-18
 ### Added

--- a/iobs/commands/execute.py
+++ b/iobs/commands/execute.py
@@ -122,6 +122,7 @@ def execute(args):
             configuration.validate()
 
             if args.reset_device:
+                configuration.save_system_environment()
                 configuration.save_device_environments()
 
             configuration.process()
@@ -134,6 +135,7 @@ def execute(args):
                    print_type=PrintType.ERROR | PrintType.ERROR_LOG)
         finally:
             if args.reset_device:
+                configuration.restore_system_environment()
                 configuration.restore_device_environments()
 
     printf('Finishing program execution...',

--- a/iobs/config/base.py
+++ b/iobs/config/base.py
@@ -21,8 +21,10 @@ from iobs.errors import InvalidSettingError
 from iobs.output import printf, PrintType
 from iobs.process import (
     change_nomerges,
+    change_randomize_va_space,
     change_scheduler,
     get_device_nomerges,
+    get_randomize_va_space,
     get_device_scheduler
 )
 
@@ -178,6 +180,9 @@ class Configuration:
         """Processes the configuration."""
         printf('Processing input file {}'.format(self._input_file),
                print_type=PrintType.DEBUG_LOG)
+
+        if self._workload_type == 'filebench':
+            change_randomize_va_space(0)
 
         for wc in self._workload_configurations:
             wc.process(

--- a/iobs/config/base.py
+++ b/iobs/config/base.py
@@ -167,6 +167,7 @@ class Configuration:
         self._environment_configuration = environment_configuration
         self._workload_configurations = []
         self._device_environments = {}
+        self._system_environment = {}
 
     def add_workload_configuration(self, workload_configuration):
         """Adds a WorkloadConfiguration to process.
@@ -214,6 +215,17 @@ class Configuration:
             change_nomerges(device, de['nomerges'])
             change_scheduler(device, de['scheduler'])
 
+    def restore_system_environment(self):
+        """Restores system environment.
+
+        NOTE: This should be called after `save_environment` has been called.
+        """
+        printf('Restoring system information...',
+               print_type=PrintType.DEBUG_LOG)
+
+        se = self._system_environment
+        change_randomize_va_space(se['randomize_va_space'])
+
     def save_device_environments(self):
         """Saves device environment information so it can be restored.
 
@@ -232,6 +244,21 @@ class Configuration:
 
             printf('Saving device {} environment: {}'.format(device, de),
                    print_type=PrintType.DEBUG_LOG)
+
+    def save_system_environment(self):
+        """Saves system environment information so it can be restored.
+
+        NOTE: This should be called after `validate` has bee called.
+        """
+        printf('Saving system information...',
+               print_type=PrintType.DEBUG_LOG)
+
+        self._system_environment = {
+            'randomize_va_space': get_randomize_va_space()
+        }
+
+        printf('Saving system environment: {}'.format(self._system_environment),
+               print_type=PrintType.DEBUG_LOG)
 
     def validate(self):
         """Validates the configuration."""

--- a/iobs/errors.py
+++ b/iobs/errors.py
@@ -71,6 +71,10 @@ class SchedulerChangeError(IOBSBaseException):
     """Scheduler Change Error"""
 
 
+class SystemSettingChangeError(IOBSBaseException):
+    """System Setting Change Error"""
+
+
 class UndefinedConstantError(IOBSBaseException):
     """Undefined Constant Error"""
 

--- a/iobs/errors.py
+++ b/iobs/errors.py
@@ -23,6 +23,10 @@ class ConfigNotFoundError(IOBSBaseException):
     """Config Not Found Error"""
 
 
+class DeviceSettingChangeError(IOBSBaseException):
+    """Device Setting Change Error"""
+
+
 class InvalidConfigError(IOBSBaseException):
     """Invalid Config Error"""
 
@@ -45,10 +49,6 @@ class InvalidSettingError(IOBSBaseException):
 
 class JobExecutionError(IOBSBaseException):
     """Job Execution Error"""
-
-
-class NomergesChangeError(IOBSBaseException):
-    """Nomerges Change Error"""
 
 
 class OutputFileError(IOBSBaseException):

--- a/iobs/process.py
+++ b/iobs/process.py
@@ -24,6 +24,7 @@ import subprocess
 
 from iobs.errors import (
     DeviceSettingChangeError,
+    SystemSettingChangeError,
     SchedulerChangeError
 )
 from iobs.output import printf, PrintType
@@ -168,6 +169,31 @@ def change_nomerges(device, nomerges):
         raise DeviceSettingChangeError(
             'Unable to change nomerges to {} for device {}'
             .format(nomerges, device)
+        )
+
+
+def change_randomize_va_space(randomize_va_space):
+    """Changes the randomize_va_space setting for the given device.
+
+    Args:
+        randomize_va_space: The randomize_va_space setting.
+
+    Returns:
+        True if successful, else False.
+    """
+    printf('Changing randomize_va_space for system to {}'
+           .format(randomize_va_space),
+           print_type=PrintType.DEBUG_LOG)
+
+    command = 'bash -c "echo {} > /proc/sys/kernel/randomize_va_space"' \
+              .format(randomize_va_space)
+
+    _, rc = run_command(command)
+
+    if rc != 0:
+        raise SystemSettingChangeError(
+            'Unable to change randomize_va_space to {} for system'
+            .format(randomize_va_space)
         )
 
 
@@ -346,6 +372,25 @@ def get_device_scheduler(device):
            print_type=PrintType.DEBUG_LOG)
 
     return ret
+
+
+def get_randomize_va_space():
+    """Returns the current randomize_va_space for the system.
+
+    Returns:
+        The current randomize_va_space setting.
+    """
+    printf('Retrieving randomize_va_space for system',
+           print_type=PrintType.DEBUG_LOG)
+
+    out, rc = run_command('cat /proc/sys/kernel/randomize_va_space')
+
+    if rc != 0:
+        printf('Unable to find randomize_va_space for system',
+               print_type=PrintType.ERROR_LOG)
+        return []
+
+    return int(out)
 
 
 def get_schedulers_for_device(device):

--- a/iobs/process.py
+++ b/iobs/process.py
@@ -23,7 +23,7 @@ import stat
 import subprocess
 
 from iobs.errors import (
-    NomergesChangeError,
+    DeviceSettingChangeError,
     SchedulerChangeError
 )
 from iobs.output import printf, PrintType
@@ -165,7 +165,7 @@ def change_nomerges(device, nomerges):
     _, rc = run_command(command)
 
     if rc != 0:
-        raise NomergesChangeError(
+        raise DeviceSettingChangeError(
             'Unable to change nomerges to {} for device {}'
             .format(nomerges, device)
         )


### PR DESCRIPTION
Filebench workloads may stall if `/proc/sys/kernel/randomize_va_space` is not set to 0. This is mentioned [here](https://github.com/filebench/filebench/issues/60) and has yet to be fixed.